### PR TITLE
Added duplicate labels check to file_to_genome_id_map file

### DIFF
--- a/bin/GToTree
+++ b/bin/GToTree
@@ -244,9 +244,9 @@ fi
 
 # checking no duplicates labels in label file
 if [ -f "$file_to_genome_id_map" ]; then
-    num_dupes=$(cut -f 2 -d$'\t' "$file_to_genome_id_map" | uniq -d | wc -l)
+    num_dupes=$(cut -f 2,3 "$file_to_genome_id_map" | tr "\t" "_" | sort | uniq -d | wc -l)
     if [ ! $num_dupes == 0 ]; then
-        printf "\n${RED}      $file_to_genome_id_map has duplicate labels on the second column, check it out and provide unique labels only.${NC}\n"
+        printf "\n${RED} $file_to_genome_id_map appears to have duplicate labels in there, check it out and provide unique labels only.${NC}\n"
         printf "\nExiting for now.\n\n"
         exit
     fi

--- a/bin/GToTree
+++ b/bin/GToTree
@@ -242,6 +242,16 @@ if [ -f "$NCBI_acc_file" ]; then
     fi
 fi
 
+# checking no duplicates labels in label file
+if [ -f "$file_to_genome_id_map" ]; then
+    num_dupes=$(cut -f 2 -d$'\t' "$file_to_genome_id_map" | uniq -d | wc -l)
+    if [ ! $num_dupes == 0 ]; then
+        printf "\n${RED}      $file_to_genome_id_map has duplicate labels on the second column, check it out and provide unique labels only.${NC}\n"
+        printf "\nExiting for now.\n\n"
+        exit
+    fi
+fi
+
 # checking numeric inputs and setting defaults if not provided
 if [ -z $len_cutoff ]; then
     len_cutoff="0.2"


### PR DESCRIPTION
Referring to #14 , if merged, this PR will: 
- Add a check to prevent the workflow from running if there are duplicate labels in the mapping file.

If  there are duplicate labels, the workflow runs normally but the tree file comes out empty due to FastTree not accepting duplicate labels. However, the alignment file will have sequences will duplicate labels, making it difficult. to distinguish from which genome they originated.

I tried to add a block much like the one in [line 235](https://github.com/AstrobioMike/GToTree/blob/04fa12fdcd05788cc9edd44fe845bca324b98934/bin/GToTree#L235). However, I'm not very proficient with bash, so I kindly ask that it is tested and debugged if needed.

Hope you find this PR useful.

Best,
V